### PR TITLE
[design/#53] 캘린더 이벤트 등록시 모달창을 위해 페이지 추가

### DIFF
--- a/Frontend/src/views/pages/calendar/EventDetailModal.vue
+++ b/Frontend/src/views/pages/calendar/EventDetailModal.vue
@@ -1,0 +1,95 @@
+<template>
+    <div class="modal-overlay" v-if="isOpen">
+        <div class="modal-container">
+            <h3 class="modal-title">이벤트 상세 정보</h3>
+            <div v-if="event">
+                <p><strong>이름:</strong> {{ event.title }}</p>
+                <p><strong>카테고리:</strong> {{ event.extendedProps.category }}</p>
+                <p><strong>시작 날짜 및 시간:</strong> {{ formatDate(event.start) }}</p>
+                <p><strong>종료 날짜 및 시간:</strong> {{ formatDate(event.end) }}</p>
+            </div>
+            <div class="modal-actions">
+                <button @click="deleteEvent">삭제</button>
+                <button @click="closeModal">닫기</button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        isOpen: Boolean,
+        event: Object
+    },
+    methods: {
+        formatDate(date) {
+            if (!date) return 'N/A';
+            return new Date(date).toLocaleString('en-US', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+            });
+        },
+        closeModal() {
+            this.$emit('close');
+        },
+        deleteEvent() {
+            if (confirm(`이벤트 '${this.event.title}'를 삭제하시겠습니까?`)) {
+                this.$emit('delete', this.event);
+                this.closeModal();
+            }
+        }
+    }
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-container {
+    background: white;
+    padding: 2em;
+    border-radius: 5px;
+    width: 300px;
+}
+
+.modal-title {
+    text-align: center;
+    font-size: 1.5em;
+    margin-bottom: 1em;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 1em;
+}
+
+button {
+    padding: 0.5em 1em;
+    border: none;
+    background-color: #f44336;
+    color: white;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+button:last-child {
+    background-color: #ddd;
+    color: black;
+}
+</style>

--- a/Frontend/src/views/pages/calendar/EventModal.vue
+++ b/Frontend/src/views/pages/calendar/EventModal.vue
@@ -1,0 +1,117 @@
+<template>
+    <div class="modal-overlay" v-if="isOpen">
+        <div class="modal-container">
+            <h3 class="modal-title">이벤트 생성</h3>
+            <form @submit.prevent="submitForm">
+                <div>
+                    <label for="title">이벤트 이름:</label>
+                    <input type="text" v-model="eventData.title" id="title" required />
+                </div>
+                <div>
+                    <label for="start">시작 날짜 및 시간:</label>
+                    <input type="datetime-local" v-model="eventData.start" id="start" required />
+                </div>
+                <div>
+                    <label for="end">종료 날짜 및 시간:</label>
+                    <input type="datetime-local" v-model="eventData.end" id="end" />
+                </div>
+                <div>
+                    <label for="category">카테고리:</label>
+                    <select v-model="eventData.category" id="category" required>
+                        <option value="휴가">휴가</option>
+                        <option value="출근">출근</option>
+                        <option value="병가">병가</option>
+                        <option value="조퇴">조퇴</option>
+                    </select>
+                </div>
+                <div class="modal-actions">
+                    <button type="submit">저장</button>
+                    <button type="button" @click="closeModal">취소</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        isOpen: Boolean,
+        initialData: Object
+    },
+    data() {
+        return {
+            eventData: {
+                title: '',
+                start: '',
+                end: '',
+                category: '출근'
+            }
+        };
+    },
+    watch: {
+        initialData(newData) {
+            if (newData) {
+                this.eventData = { ...newData };
+            }
+        }
+    },
+    methods: {
+        closeModal() {
+            this.$emit('close');
+        },
+        submitForm() {
+            this.$emit('save', this.eventData);
+            this.closeModal();
+        }
+    }
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-container {
+    background: white;
+    padding: 2em;
+    border-radius: 5px;
+    width: 300px;
+}
+
+.modal-title {
+    text-align: center;
+    font-size: 1.5em;
+    margin-bottom: 1em;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 1em;
+}
+
+button {
+    padding: 0.5em 1em;
+    border: none;
+    background-color: #007bff;
+    color: white;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+button:last-child {
+    background-color: #ddd;
+    color: black;
+}
+</style>

--- a/Frontend/src/views/pages/calendar/utils/data.js
+++ b/Frontend/src/views/pages/calendar/utils/data.js
@@ -1,0 +1,96 @@
+import { createEventId } from './event-utils';
+
+export const INITIAL_EVENTS = [
+    {
+        id: createEventId(),
+        title: '휴가',
+        start: '2024-09-02',
+        end: '2024-09-04',
+        backgroundColor: '#ffcccc',
+        extendedProps: {
+            category: '휴가'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '회의',
+        start: '2024-09-05T10:00:00',
+        backgroundColor: '#ccffcc',
+        extendedProps: {
+            category: '회의'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '출근',
+        start: '2024-09-06T09:00:00',
+        backgroundColor: '#cce6ff',
+        extendedProps: {
+            category: '출근'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '프로젝트 마감',
+        start: '2024-09-07',
+        backgroundColor: '#ffe6cc',
+        extendedProps: {
+            category: '마감'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '병가',
+        start: '2024-09-08',
+        backgroundColor: '#ffe6cc',
+        extendedProps: {
+            category: '병가'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '조퇴',
+        start: '2024-09-09T14:00:00',
+        backgroundColor: '#ffcccc',
+        extendedProps: {
+            category: '조퇴'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '휴가',
+        start: '2024-09-10',
+        end: '2024-09-12',
+        backgroundColor: '#ffcccc',
+        extendedProps: {
+            category: '휴가'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '회의',
+        start: '2024-09-13T15:00:00',
+        backgroundColor: '#ccffcc',
+        extendedProps: {
+            category: '회의'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '출근',
+        start: '2024-09-14T09:00:00',
+        backgroundColor: '#cce6ff',
+        extendedProps: {
+            category: '출근'
+        }
+    },
+    {
+        id: createEventId(),
+        title: '프로젝트 리뷰',
+        start: '2024-09-15',
+        backgroundColor: '#ffe6cc',
+        extendedProps: {
+            category: '리뷰'
+        }
+    }
+];


### PR DESCRIPTION
## 📢 기능 설명
기본 캘린더
<br>
<img width="1616" alt="스크린샷 2024-09-02 02 35 38" src="https://github.com/user-attachments/assets/b61abf6e-dcaa-478e-b082-6a565ba916f5">
<br><br>
이벤트 생성 modal <br>
<img width="1616" alt="스크린샷 2024-09-02 02 36 24" src="https://github.com/user-attachments/assets/5a98f52d-5191-439e-9e41-3310f8483913">
<br><br>
이벤트 상세 modal <br>
<img width="1616" alt="스크린샷 2024-09-02 02 37 04" src="https://github.com/user-attachments/assets/a61dbd36-814d-4978-a4ef-b3b31ddaa47c">
<br>

## 연결된 issue
연결된 Issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #53 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가?
  - ex) [feat/#21] 회원 로그인 기능부분 구현
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가? 